### PR TITLE
Part 3: Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ The URI for this test stub in Mocky is https://run.mocky.io/v3/0dfda26a-3a5a-43e
 
 # Candidate Notes
 * Have made an assumption that `mileage` would be required as a query string param when calling the Premium Car API, as it's missing from the swagger. Would normally get this confirmed before implementing
-* The tests for `fetchCarValuation` duplicate some of tests from the Circuit Breaker class. Could have opted to provide a mock instance of the breaker or spy on the run function to determine outcome, but wanted to ensure it was behaving as expected
-* Currently no logging throughout the application, would look to add more logs on a production app.
+* The tests for `fetchCarValuation` duplicate some of tests from the Circuit Breaker class. Could have opted to provide a mock instance of the breaker or spy on the `run` function to determine outcome, but wanted to ensure it was behaving as expected
+* Currently little logging throughout the application, would look to add more logs on a production app.
 * `responseWrapper` in the fetch car valuation adapter currently swallows the original error(s). May be preferable to have the Circuit Breaker accept a logger in the config and log original errors returned from TPP's
+* In the interest of time, I have used the `any` type in a few places, which I would normally avoid wherever possible
+* Looking back on the implementation of the `CircuitBreaker` class, I think it is doing too much and I may reduce the scope of its responsibilities. When building, I liked the idea of the Circuit Breaker also handling how to handle the fallback function. However I think this has increased the responsibility and complexity of the class, so may have done this elsewhere in a larger refactor.
+* To complete the final task, I would have created a new TypeORM model `ProviderLog` with the relevant columns and attributes.  The `fetchCarValuation` adapter could then handle also timing and persisting these records as requests are made to the TPPs

--- a/src/adapters/__tests__/fetchCarValuation.test.ts
+++ b/src/adapters/__tests__/fetchCarValuation.test.ts
@@ -16,6 +16,7 @@ const valuation: VehicleValuation = {
   lowestValue: 1_000,
   highestValue: 2_000,
   midpointValue: 1_500,
+  providerName: 'SuperCarValuation',
 };
 
 describe('fetchCarValuation', () => {

--- a/src/adapters/__tests__/premium-car-valuations.test.ts
+++ b/src/adapters/__tests__/premium-car-valuations.test.ts
@@ -30,6 +30,7 @@ describe('fetchValuationFromPremiumCarValuation', () => {
       vrm,
       lowestValue: 9_500,
       highestValue: 10_275,
+      providerName: 'PremiumCarValuation',
     });
   });
 });

--- a/src/adapters/__tests__/premium-car-valuations.test.ts
+++ b/src/adapters/__tests__/premium-car-valuations.test.ts
@@ -1,8 +1,9 @@
+import { premiumCarValuationUrl } from '@app/config';
 import { fetchValuationFromPremiumCarValuation } from '../premium-car/premium-car-valuation';
 import axios from 'axios';
 
 vi.mock("axios");
-const mockAxiosGet = vi.mocked(axios.get);
+const mockAxios = vi.mocked(axios);
 
 const mockResponse = `<?xml version="1.0" encoding="UTF-8" ?>
 <root>
@@ -21,7 +22,7 @@ describe('fetchValuationFromPremiumCarValuation', () => {
   });
 
   it("successfully fetches and parses the valuation", async () => {
-    mockAxiosGet.mockResolvedValue({ status: 200, data: mockResponse });
+    mockAxios.mockResolvedValue({ status: 200, data: mockResponse });
 
     const vrm = "ABC123";
     const valuation = await fetchValuationFromPremiumCarValuation(vrm, 10000);
@@ -31,6 +32,14 @@ describe('fetchValuationFromPremiumCarValuation', () => {
       lowestValue: 9_500,
       highestValue: 10_275,
       providerName: 'PremiumCarValuation',
+    });
+    expect(mockAxios).toHaveBeenCalledWith({
+      url: premiumCarValuationUrl,
+      method: 'GET',
+      params: {
+        vrm,
+        mileage: 10000,
+      },
     });
   });
 });

--- a/src/adapters/premium-car/premium-car-valuation.ts
+++ b/src/adapters/premium-car/premium-car-valuation.ts
@@ -1,20 +1,24 @@
 import axios from 'axios';
 import { parseStringPromise } from 'xml2js';
 
-import { VehicleValuation } from '../../models/vehicle-valuation';
+import { premiumCarValuationUrl } from '@app/config';
+import { VehicleValuation } from '@app/models/vehicle-valuation';
 import { PremiumCarValuationResponse } from './types/premium-car-valuation-response';
 
 export async function fetchValuationFromPremiumCarValuation(
   vrm: string,
   mileage: number,
 ): Promise<VehicleValuation> {
-  axios.defaults.baseURL =
-    'https://run.mocky.io/v3/0dfda26a-3a5a-43e5-b68c-51f148eda473';
   // data will be an xml string, needs parsing to an object
-  // mileage is missing from the swagger doc, but going to assume a mistake and would be required to obtain a valuation
-  const response = await axios.get<string>(
-    `valueCar?vrm=${vrm}&mileage=${mileage}`,
-  );
+  const response = await axios<string>({
+    url: premiumCarValuationUrl,
+    method: 'GET',
+    params: {
+      vrm,
+      // mileage is missing from the swagger doc, but going to assume a mistake and would be required to obtain a valuation
+      mileage,
+    },
+  });
 
   const premiumCarValuation = await parsePremiumCarValuationResponse(response.data);
 

--- a/src/adapters/premium-car/premium-car-valuation.ts
+++ b/src/adapters/premium-car/premium-car-valuation.ts
@@ -18,13 +18,12 @@ export async function fetchValuationFromPremiumCarValuation(
 
   const premiumCarValuation = await parsePremiumCarValuationResponse(response.data);
 
-  const valuation = new VehicleValuation();
-
-  valuation.vrm = vrm;
-  valuation.lowestValue = premiumCarValuation.dealershipValuation.lowerValue;
-  valuation.highestValue = premiumCarValuation.dealershipValuation.upperValue;
-
-  return valuation;
+  return VehicleValuation.from({
+    vrm,
+    lowestValue: premiumCarValuation.dealershipValuation.lowerValue,
+    highestValue: premiumCarValuation.dealershipValuation.upperValue,
+    providerName: 'PremiumCarValuation',
+  });
 }
 
 const parsePremiumCarValuationResponse = async (xmlData: string): Promise<PremiumCarValuationResponse> => {

--- a/src/adapters/super-car/super-car-valuation.ts
+++ b/src/adapters/super-car/super-car-valuation.ts
@@ -13,11 +13,10 @@ export async function fetchValuationFromSuperCarValuation(
     `valuations/${vrm}?mileage=${mileage}`,
   );
 
-  const valuation = new VehicleValuation();
-
-  valuation.vrm = vrm;
-  valuation.lowestValue = response.data.valuation.lowerValue;
-  valuation.highestValue = response.data.valuation.upperValue;
-
-  return valuation;
+  return VehicleValuation.from({
+    vrm,
+    lowestValue: response.data.valuation.lowerValue,
+    highestValue: response.data.valuation.upperValue,
+    providerName: 'SuperCarValuation',
+  });
 }

--- a/src/adapters/super-car/super-car-valuation.ts
+++ b/src/adapters/super-car/super-car-valuation.ts
@@ -2,16 +2,20 @@ import axios from 'axios';
 
 import { VehicleValuation } from '../../models/vehicle-valuation';
 import { SuperCarValuationResponse } from './types/super-car-valuation-response';
+import { superCarValuationUrl } from '@app/config';
 
 export async function fetchValuationFromSuperCarValuation(
   vrm: string,
   mileage: number,
 ): Promise<VehicleValuation> {
-  axios.defaults.baseURL =
-    'https://run.mocky.io/v3/9245229e-5c57-44e1-964b-36c7fb29168b';
-  const response = await axios.get<SuperCarValuationResponse>(
-    `valuations/${vrm}?mileage=${mileage}`,
-  );
+  const response = await axios<SuperCarValuationResponse>({
+    url: superCarValuationUrl,
+    method: 'GET',
+    params: {
+      vrm,
+      mileage,
+    },
+  });
 
   return VehicleValuation.from({
     vrm,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,3 +7,6 @@ export const circuitBreakerConfig: CircuitBreakerConfig = {
   failureThresholdPercentage: failureThresholdPercentage ? parseInt(failureThresholdPercentage, 10) : 50,
   resetTimeout: resetTimeout ? parseInt(resetTimeout, 10) : 60_000,
 };
+
+export const premiumCarValuationUrl = process.env.PREMIUM_CAR_VALUATION_URL || 'https://run.mocky.io/v3/0dfda26a-3a5a-43e5-b68c-51f148eda473';
+export const superCarValuationUrl = process.env.SUPER_CAR_VALUATION_URL || 'https://run.mocky.io/v3/9245229e-5c57-44e1-964b-36c7fb29168b';

--- a/src/models/vehicle-valuation.ts
+++ b/src/models/vehicle-valuation.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, PrimaryColumn, Repository } from 'typeorm';
 
 export type VehicleValuationDto = {
   vrm: string;
@@ -34,3 +34,6 @@ export class VehicleValuation {
     return (this.highestValue + this.lowestValue) / 2;
   }
 }
+
+export const getVehicleValuationByVrm = async (vrm: string, repository: Repository<VehicleValuation>) =>
+  repository.findOneBy({ vrm });

--- a/src/models/vehicle-valuation.ts
+++ b/src/models/vehicle-valuation.ts
@@ -1,7 +1,23 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
+export type VehicleValuationDto = {
+  vrm: string;
+  lowestValue: number;
+  highestValue: number;
+  providerName?: string;
+};
+
 @Entity()
 export class VehicleValuation {
+  static from(valuation: VehicleValuationDto): VehicleValuation {
+    const vehicleValuation = new VehicleValuation();
+    vehicleValuation.vrm = valuation.vrm;
+    vehicleValuation.lowestValue = valuation.lowestValue;
+    vehicleValuation.highestValue = valuation.highestValue;
+    vehicleValuation.providerName = valuation.providerName;
+    return vehicleValuation;
+  }
+
   @PrimaryColumn({ length: 7 })
   vrm: string;
 
@@ -10,6 +26,9 @@ export class VehicleValuation {
 
   @Column({ type: 'decimal', precision: 10, scale: 2 })
   highestValue: number;
+
+  @Column({ type: 'text', nullable: true })
+  providerName?: string;
 
   get midpointValue(): number {
     return (this.highestValue + this.lowestValue) / 2;

--- a/src/routes/valuation/__tests__/valuation.test.ts
+++ b/src/routes/valuation/__tests__/valuation.test.ts
@@ -132,6 +132,29 @@ describe('ValuationController (e2e)', () => {
         lowestValue,
       });
     });
+
+    it('should return an existing valuation if one exists', async () => {
+      const existingValuation = {
+        vrm: 'ABC123',
+        highestValue: 20_000,
+        lowestValue: 15_000,
+      };
+      vi.spyOn(fastify.orm, 'getRepository').mockReturnValueOnce({
+        findOneBy: vi.fn().mockResolvedValueOnce(existingValuation),
+      } as any);
+
+      const requestBody: VehicleValuationRequest = {
+        mileage: 10_000,
+      };
+      const res = await fastify.inject({
+        url: `/valuations/${existingValuation.vrm}`,
+        method: 'PUT',
+        body: requestBody,
+      });
+
+      expect(res.statusCode).toStrictEqual(200);
+      expect(JSON.parse(res.body)).toEqual(existingValuation);
+    });
   });
 
   describe('GET /valuations/:vrm', () => {

--- a/src/routes/valuation/__tests__/valuation.test.ts
+++ b/src/routes/valuation/__tests__/valuation.test.ts
@@ -6,7 +6,7 @@ import { VehicleValuationRequest } from '../types/vehicle-valuation-request';
 
 vi.mock("axios");
 
-const mockAxiosGet = vi.mocked(axios.get);
+const mockAxios = vi.mocked(axios);
 
 describe('ValuationController (e2e)', () => {
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('ValuationController (e2e)', () => {
         findOneBy: vi.fn().mockResolvedValueOnce(null),
       } as any);
 
-      mockAxiosGet.mockRejectedValue(new Error('test'));
+      mockAxios.mockRejectedValue(new Error('test'));
       
       const requestBody: VehicleValuationRequest = {
         mileage: 10000,
@@ -109,7 +109,7 @@ describe('ValuationController (e2e)', () => {
         },
       };
 
-      mockAxiosGet.mockResolvedValue({
+      mockAxios.mockResolvedValue({
         status: 200,
         data: mockApiResponse,
       })

--- a/src/routes/valuation/__tests__/valuation.test.ts
+++ b/src/routes/valuation/__tests__/valuation.test.ts
@@ -15,12 +15,15 @@ describe('ValuationController (e2e)', () => {
 
   describe('PUT /valuations/:vrm', () => {
     it('should return a 503 when both valuation providers are down', async () => {
+      vi.spyOn(fastify.orm, 'getRepository').mockReturnValueOnce({
+        findOneBy: vi.fn().mockResolvedValueOnce(null),
+      } as any);
+
+      mockAxiosGet.mockRejectedValue(new Error('test'));
+      
       const requestBody: VehicleValuationRequest = {
         mileage: 10000,
       };
-
-      mockAxiosGet.mockRejectedValue(new Error('test'));
-
       const res = await fastify.inject({
         url: '/valuations/ABC123',
         body: requestBody,
@@ -112,6 +115,7 @@ describe('ValuationController (e2e)', () => {
 
       // prefer to avoid any type where possible, but allows us to simply mock the only fn used
       vi.spyOn(fastify.orm, 'getRepository').mockReturnValueOnce({
+        findOneBy: vi.fn().mockResolvedValueOnce(null),
         insert: vi.fn().mockResolvedValueOnce({}),
       } as any);
 

--- a/src/routes/valuation/__tests__/valuation.test.ts
+++ b/src/routes/valuation/__tests__/valuation.test.ts
@@ -1,5 +1,6 @@
 import { fastify, circuitBreaker } from '~root/test/fastify';
 import { SuperCarValuationResponse } from '@app/adapters/super-car/types/super-car-valuation-response';
+import { VehicleValuationDto } from '@app/models/vehicle-valuation';
 import axios from 'axios';
 import { VehicleValuationRequest } from '../types/vehicle-valuation-request';
 
@@ -134,6 +135,7 @@ describe('ValuationController (e2e)', () => {
         vrm,
         highestValue,
         lowestValue,
+        providerName: 'SuperCarValuation',
       });
     });
 
@@ -199,7 +201,7 @@ describe('ValuationController (e2e)', () => {
 
     it('should return 200 status and valuation when found for VRM', async () => {
       const vrm = 'ABC123';
-      const valuation = {
+      const valuation: VehicleValuationDto = {
         vrm,
         highestValue: 20_000,
         lowestValue: 15_000,

--- a/src/routes/valuation/index.ts
+++ b/src/routes/valuation/index.ts
@@ -22,7 +22,7 @@ export function valuationRoutes(fastify: FastifyInstance) {
         .send({ message: 'vrm must be 7 characters or less', statusCode: 400 });
     }
 
-    const result = await valuationRepository.findOneBy({ vrm: vrm });
+    const result = await valuationRepository.findOneBy({ vrm });
 
     if (result === null) {
       fastify.log.warn('Valuation not found for VRM: ', vrm);

--- a/src/routes/valuation/index.ts
+++ b/src/routes/valuation/index.ts
@@ -23,7 +23,7 @@ export function valuationRoutes(fastify: FastifyInstance) {
 
     const result = await valuationRepository.findOneBy({ vrm: vrm });
 
-    if (result == null) {
+    if (result === null) {
       return reply
         .code(404)
         .send({

--- a/src/routes/valuation/index.ts
+++ b/src/routes/valuation/index.ts
@@ -60,6 +60,11 @@ export function valuationRoutes(fastify: FastifyInstance) {
         });
     }
 
+    const existingValuation = await valuationRepository.findOneBy({ vrm });
+    if (existingValuation) {
+      return existingValuation;
+    }
+
     const { data: valuation, err } = await fetchCarValuation(vrm, mileage);
     if (err) {
       return reply


### PR DESCRIPTION
* The `PUT /valuations/:vrm` endpoint now checks for an existing valuation before making the call to TPPs
* `providerName` has been added as a nullable column to the `VehicleValuation` model.  This value is now returned by the vehicle valuation adapters 
* Adds some additional logs for better visibility of the valuations routes
* Moves the TPP Api Urls to a config file, so these can easily be changed between environments and are no longer hard coded
* General readability improvements
